### PR TITLE
Migrate from OAKRunner to ArazzoRunner

### DIFF
--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "uvicorn>=0.23.2",
     "jentic>=0.8.1"
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 readme = "README.md"
 license = {text = "MIT"}
 
@@ -58,14 +58,14 @@ mcp = "mcp.main:app"
 
 [tool.black]
 line-length = 100
-target-version = ["py310"]
+target-version = ["py311"]
 
 [tool.isort]
 profile = "black"
 line_length = 100
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
 check_untyped_defs = true
@@ -78,7 +78,7 @@ warn_unused_ignores = true
 
 [tool.ruff]
 line-length = 100
-target-version = "py310"
+target-version = "py311"
 select = ["E", "F", "B", "W", "I", "N", "UP", "YTT", "S"]
 ignore = []
 

--- a/python/README.md
+++ b/python/README.md
@@ -2,7 +2,7 @@
 
 Jentic SDK is a comprehensive library for discovery and execution of APIs and workflows.
 
-The Jentic SDK is backed by the data in the [Open Agentic Knowledge (OAK)](https://github.com/jentic/oak) repository.
+The Jentic SDK is backed by the data in the [Jentic Public API](https://github.com/jentic/jentic-public-api) repository.
 
 ## Core API & Use Cases
 

--- a/python/pdm.lock
+++ b/python/pdm.lock
@@ -5,10 +5,10 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:092a1022a5b650d78d88ca8e035268adb3146fac0db39d9cb2b9cbf6b90e36fc"
+content_hash = "sha256:6e18ce210924480b77d0df6b0b6679750ab5462b48874bdde67ff501307fdaca"
 
 [[metadata.targets]]
-requires_python = ">=3.10"
+requires_python = ">=3.11"
 
 [[package]]
 name = "annotated-types"
@@ -39,6 +39,21 @@ dependencies = [
 files = [
     {file = "anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c"},
     {file = "anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028"},
+]
+
+[[package]]
+name = "arazzo-runner"
+version = "0.8.14"
+requires_python = ">=3.11"
+path = "/Users/kc/c/arazzo-engine/runner"
+summary = "Execution libraries and test tools for Arazzo workflows and Open API operations"
+groups = ["default"]
+dependencies = [
+    "jsonpath-ng>=1.5.0",
+    "jsonpointer>=3.0.0",
+    "pydantic>=2.0.0",
+    "pyyaml>=6.0",
+    "requests>=2.28.0",
 ]
 
 [[package]]
@@ -176,18 +191,6 @@ marker = "sys_platform == \"win32\" or platform_system == \"Windows\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
-]
-
-[[package]]
-name = "exceptiongroup"
-version = "1.2.2"
-requires_python = ">=3.7"
-summary = "Backport of PEP 654 (exception groups)"
-groups = ["default", "dev"]
-marker = "python_version < \"3.11\""
-files = [
-    {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
-    {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
 ]
 
 [[package]]
@@ -339,20 +342,6 @@ groups = ["dev"]
 files = [
     {file = "mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"},
     {file = "mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"},
-]
-
-[[package]]
-name = "oak-runner"
-version = "0.8.7"
-requires_python = ">=3.10"
-summary = "Execution libraries and test tools for Arazzo workflows and Open API operations"
-groups = ["default"]
-dependencies = [
-    "jsonpath-ng>=1.5.0",
-    "jsonpointer>=3.0.0",
-    "pydantic>=2.0.0",
-    "pyyaml>=6.0",
-    "requests>=2.28.0",
 ]
 
 [[package]]
@@ -659,48 +648,6 @@ groups = ["default"]
 files = [
     {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
     {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
-]
-
-[[package]]
-name = "tomli"
-version = "2.2.1"
-requires_python = ">=3.8"
-summary = "A lil' TOML parser"
-groups = ["dev"]
-marker = "python_version < \"3.11\""
-files = [
-    {file = "tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249"},
-    {file = "tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6"},
-    {file = "tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a"},
-    {file = "tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee"},
-    {file = "tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e"},
-    {file = "tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4"},
-    {file = "tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106"},
-    {file = "tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8"},
-    {file = "tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff"},
-    {file = "tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b"},
-    {file = "tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea"},
-    {file = "tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8"},
-    {file = "tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192"},
-    {file = "tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222"},
-    {file = "tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77"},
-    {file = "tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6"},
-    {file = "tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd"},
-    {file = "tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e"},
-    {file = "tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98"},
-    {file = "tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4"},
-    {file = "tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7"},
-    {file = "tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c"},
-    {file = "tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13"},
-    {file = "tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281"},
-    {file = "tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272"},
-    {file = "tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140"},
-    {file = "tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2"},
-    {file = "tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744"},
-    {file = "tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec"},
-    {file = "tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69"},
-    {file = "tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc"},
-    {file = "tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff"},
 ]
 
 [[package]]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "jentic"
 
-version = "0.8.1"
+version = "0.8.2"
 
 description = "Jentic SDK for the discovery and execution of APIs and workflows"
 authors = [
@@ -12,9 +12,9 @@ dependencies = [
     "pyyaml>=6.0",
     "jsonpath-ng>=1.5.0",
     "httpx>=0.28.1",
-    "oak-runner>=0.8.9"
+    "arazzo_runner>=0.8.14"
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 readme = "README.md"
 license = {text = "MIT"}
 
@@ -40,14 +40,14 @@ python_functions = "test_*"
 
 [tool.black]
 line-length = 100
-target-version = ["py310"]
+target-version = ["py311"]
 
 [tool.isort]
 profile = "black"
 line_length = 100
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
 check_untyped_defs = true
@@ -60,7 +60,7 @@ warn_unused_ignores = true
 
 [tool.ruff]
 line-length = 100
-target-version = "py310"
+target-version = "py311"
 select = ["E", "F", "B", "W", "I", "N", "UP", "YTT", "S"]
 ignore = []
 [dependency-groups]

--- a/python/src/jentic/agent_runtime/config.py
+++ b/python/src/jentic/agent_runtime/config.py
@@ -6,10 +6,10 @@ import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-from oak_runner.auth.auth_processor import AuthProcessor
-from oak_runner.auth.models import SecurityOption
-from oak_runner.extractor.openapi_extractor import extract_operation_io
-from oak_runner import OAKRunner
+from arazzo_runner.auth.auth_processor import AuthProcessor
+from arazzo_runner.auth.models import SecurityOption
+from arazzo_runner.extractor.openapi_extractor import extract_operation_io
+from arazzo_runner import ArazzoRunner
 
 from jentic.api.api_hub import JenticAPIClient
 from jentic.models import GetFilesResponse
@@ -186,7 +186,7 @@ class JenticConfig:
             )
 
         # Step 5: Process authentication requirements
-        env_mappings = OAKRunner.generate_env_mappings(arazzo_docs=all_arazzo_specs, source_descriptions=all_openapi_specs)
+        env_mappings = ArazzoRunner.generate_env_mappings(arazzo_docs=all_arazzo_specs, source_descriptions=all_openapi_specs)
 
         # Step 6: Compose final config
         final_config = {

--- a/python/src/jentic/agent_runtime/tool_execution.py
+++ b/python/src/jentic/agent_runtime/tool_execution.py
@@ -5,7 +5,7 @@ import os
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
-from oak_runner import OAKRunner, WorkflowExecutionResult, WorkflowExecutionStatus
+from arazzo_runner import ArazzoRunner, WorkflowExecutionResult, WorkflowExecutionStatus
 
 from jentic import api
 from jentic.api import JenticAPIClient
@@ -54,7 +54,7 @@ class TaskExecutor:
         self.api_hub_client = api_hub_client or JenticAPIClient()
 
     async def execute_workflow(self, workflow_uuid: str, inputs: Dict[str, Any]) -> WorkflowResult:
-        """Executes a specified workflow using OAK runner.
+        """Executes a specified workflow using Arazzo runner.
 
         Args:
             workflow_uuid: The UUID of the workflow to execute.
@@ -94,18 +94,18 @@ class TaskExecutor:
                     error=f"Arazzo document or internal workflow ID missing for {workflow_uuid}",
                 )
 
-            # 4. Instantiate OAKRunner
+            # 4. Instantiate ArazzoRunner
             logger.debug(
-                f"Instantiating OAKRunner for internal workflow ID: {friendly_workflow_id}"
+                f"Instantiating ArazzoRunner for internal workflow ID: {friendly_workflow_id}"
             )
-            runner = OAKRunner(
+            runner = ArazzoRunner(
                 arazzo_doc=arazzo_doc,
                 source_descriptions=source_descriptions,
             )
 
             # 5. Execute the workflow using the INTERNAL workflow ID
             logger.debug(
-                f"Running workflow {friendly_workflow_id} via OAKRunner with UUID {workflow_uuid}."
+                f"Running workflow {friendly_workflow_id} via ArazzoRunner with UUID {workflow_uuid}."
             )
             # Removed await as runner.execute_workflow seems synchronous based on TypeError
             execution_output: WorkflowExecutionResult = runner.execute_workflow(
@@ -136,7 +136,7 @@ class TaskExecutor:
         inputs: Dict[str, Any],
     ) -> OperationResult:
         """
-        Executes a specified API operation using OAKRunner after fetching required files from the API.
+        Executes a specified API operation using ArazzoRunner after fetching required files from the API.
 
         Args:
             operation_uuid: The UUID of the operation to execute.
@@ -167,7 +167,7 @@ class TaskExecutor:
                 )
             operation_entry = exec_files_response.operations[operation_uuid]
 
-            # Prepare OpenAPI spec for OAKRunner
+            # Prepare OpenAPI spec for ArazzoRunner
             openapi_content = None
             openapi_files = exec_files_response.files.get("open_api", {})
             if operation_entry.files.open_api:
@@ -183,8 +183,8 @@ class TaskExecutor:
                 )
             source_descriptions = {"default": openapi_content}
 
-            # Prepare OAKRunner and execute the operation
-            runner = OAKRunner(source_descriptions=source_descriptions)
+            # Prepare ArazzoRunner and execute the operation
+            runner = ArazzoRunner(source_descriptions=source_descriptions)
             # Pass operation_uuid, path, and method from the operation_entry
             oak_result: Any = runner.execute_operation(
                 inputs=inputs, operation_path=f"{operation_entry.method} {operation_entry.path}"
@@ -203,10 +203,10 @@ class TaskExecutor:
     def _process_operation_result(
         self, oak_result: Dict[str, Any], operation_uuid: str, inputs: Dict[str, Any]
     ) -> "OperationResult":
-        """Process the OAKRunner operation result, check status codes, and handle casting.
+        """Process the ArazzoRunner operation result, check status codes, and handle casting.
 
         Args:
-            oak_result: The result dictionary from OAKRunner.execute_operation.
+            oak_result: The result dictionary from ArazzoRunner.execute_operation.
             operation_uuid: The UUID of the operation being executed, for logging.
 
         Returns:

--- a/python/src/jentic/api/api_hub.py
+++ b/python/src/jentic/api/api_hub.py
@@ -128,17 +128,17 @@ class JenticAPIClient:
                 openapi_file_id = openapi_file_id_obj.id
                 if openapi_file_id in all_openapi_files:
                     file_entry = all_openapi_files[openapi_file_id]
-                    # Store content and oak_path for direct matching
-                    # Assumes file_entry has an 'oak_path' attribute from the API response
-                    if hasattr(file_entry, 'oak_path') and file_entry.oak_path is not None:
+                    # Store content and source_path for direct matching
+                    # Assumes file_entry has a 'source_path' attribute from the API response
+                    if hasattr(file_entry, 'source_path') and file_entry.source_path is not None:
                         openapi_files[openapi_file_id] = {
                             "content": file_entry.content,
-                            "oak_path": file_entry.oak_path
+                            "source_path": file_entry.source_path
                         }
-                        logger.debug(f"Found OpenAPI file with oak_path: {file_entry.oak_path} (ID: {openapi_file_id})")
+                        logger.debug(f"Found OpenAPI file with source_path: {file_entry.source_path} (ID: {openapi_file_id})")
                     else:
                         logger.warning(
-                            f"OpenAPI file entry with ID {openapi_file_id} (filename: {file_entry.filename}) is missing 'oak_path'. Cannot use for matching."
+                            f"OpenAPI file entry with ID {openapi_file_id} (filename: {file_entry.filename}) is missing 'source_path'. Cannot use for matching."
                         )
                 else:
                     logger.warning(
@@ -147,7 +147,7 @@ class JenticAPIClient:
 
             if not openapi_files:
                 logger.warning(
-                    f"No usable OpenAPI file content (with oak_path) found for workflow {workflow_entry.workflow_id} despite references."
+                    f"No usable OpenAPI file content (with source_path) found for workflow {workflow_entry.workflow_id} despite references."
                 )
         elif not all_openapi_files:
             logger.warning(
@@ -158,7 +158,7 @@ class JenticAPIClient:
                 f"Workflow {workflow_entry.workflow_id} does not reference any OpenAPI files."
             )
 
-        # 3. Map each Arazzo source description to matching OpenAPI content by oak_path
+        # 3. Map each Arazzo source description to matching OpenAPI content by source_path
         if arazzo_source_names and openapi_files:
             # Extract source descriptions with their URLs
             arazzo_sources_with_urls = []
@@ -173,33 +173,33 @@ class JenticAPIClient:
             except Exception as e:
                 logger.error(f"Error extracting URLs from sourceDescriptions: {e}")
             
-            # Match Arazzo sourceDescriptions to OpenAPI files by comparing source.url with file.oak_path
+            # Match Arazzo sourceDescriptions to OpenAPI files by comparing source.url with file.source_path
             for source in arazzo_sources_with_urls:
                 source_name = source["name"]
                 source_url = source["url"]
                 
                 matched = False
                 for file_id, file_info in openapi_files.items():
-                    openapi_oak_path = file_info["oak_path"]
+                    openapi_source_path = file_info["source_path"]
                     
-                    if source_url == openapi_oak_path:
+                    if source_url == openapi_source_path:
                         source_descriptions[source_name] = file_info["content"]
                         matched = True
                         logger.info(
                             f"Matched Arazzo source '{source_name}' (URL: {source_url}) "
-                            f"to OpenAPI file with oak_path '{openapi_oak_path}' (ID: {file_id})"
+                            f"to OpenAPI file with source_path '{openapi_source_path}' (ID: {file_id})"
                         )
                         break # Found the match for this Arazzo source
                 
                 if not matched:
                     logger.warning(
-                        f"Could not find an OpenAPI file with oak_path matching Arazzo sourceDescription URL '{source_url}' "
+                        f"Could not find an OpenAPI file with source_path matching Arazzo sourceDescription URL '{source_url}' "
                         f"for source name '{source_name}' in workflow {workflow_entry.workflow_id}. This source will not be available."
                     )
 
         elif not openapi_files and arazzo_source_names:
             logger.warning(
-                f"No OpenAPI files with oak_path were available to match against Arazzo source descriptions for workflow {workflow_entry.workflow_id}."
+                f"No OpenAPI files with source_path were available to match against Arazzo source descriptions for workflow {workflow_entry.workflow_id}."
             )
 
         if not source_descriptions and arazzo_source_names:

--- a/python/tests/agent_runtime/test_tool_execution.py
+++ b/python/tests/agent_runtime/test_tool_execution.py
@@ -20,7 +20,7 @@ from jentic.models import (
     WorkflowEntry,
     WorkflowExecutionDetails,
 )
-from oak_runner import WorkflowExecutionResult as OakWorkflowExecutionResult, WorkflowExecutionStatus
+from arazzo_runner import WorkflowExecutionResult as OakWorkflowExecutionResult, WorkflowExecutionStatus
 
 
 @pytest.fixture
@@ -88,9 +88,9 @@ class TestWorkflowExecution:
         )
 
         # Create a mock runner
-        with patch("jentic.agent_runtime.tool_execution.OAKRunner") as mock_runner_class:
-            mock_runner = MagicMock()  # OAKRunner.execute_workflow is synchronous
-            # Update return value structure for OAKRunner
+        with patch("jentic.agent_runtime.tool_execution.ArazzoRunner") as mock_runner_class:
+            mock_runner = MagicMock()  # ArazzoRunner.execute_workflow is synchronous
+            # Update return value structure for ArazzoRunner
             mock_runner.execute_workflow.return_value = OakWorkflowExecutionResult(
                 status=WorkflowExecutionStatus.WORKFLOW_COMPLETE,
                 workflow_id=friendly_workflow_id,
@@ -145,7 +145,7 @@ class TestWorkflowExecution:
         )
 
         # Create a mock runner that returns an error status
-        with patch("jentic.agent_runtime.tool_execution.OAKRunner") as mock_runner_class:
+        with patch("jentic.agent_runtime.tool_execution.ArazzoRunner") as mock_runner_class:
             mock_runner = MagicMock()
             mock_runner.execute_workflow.return_value = OakWorkflowExecutionResult(
                 status=WorkflowExecutionStatus.ERROR,
@@ -192,8 +192,8 @@ class TestWorkflowExecution:
         # Setup mock API Hub to return an empty dictionary (details not found)
         mock_api_hub_client.get_execution_details_for_workflow.return_value = None
 
-        # Patch OAKRunner to ensure it's not called
-        with patch("jentic.agent_runtime.tool_execution.OAKRunner") as mock_runner_class:
+        # Patch ArazzoRunner to ensure it's not called
+        with patch("jentic.agent_runtime.tool_execution.ArazzoRunner") as mock_runner_class:
             # Create the tool executor
             executor = TaskExecutor(mock_api_hub_client)  
 
@@ -227,7 +227,7 @@ class TestWorkflowExecution:
         )
 
         # Mock runner class to raise an exception during instantiation
-        with patch("jentic.agent_runtime.tool_execution.OAKRunner") as mock_runner_class:
+        with patch("jentic.agent_runtime.tool_execution.ArazzoRunner") as mock_runner_class:
             mock_runner_class.side_effect = Exception("Runner Init Error")
 
             # Create the tool executor
@@ -269,7 +269,7 @@ class TestCompleteWorkflowExecution:
         )
 
         # Mock the runner
-        with patch("jentic.agent_runtime.tool_execution.OAKRunner") as mock_runner_class:
+        with patch("jentic.agent_runtime.tool_execution.ArazzoRunner") as mock_runner_class:
             mock_runner = MagicMock()  
             # Update return value structure
             mock_runner.execute_workflow.return_value = OakWorkflowExecutionResult(
@@ -317,7 +317,7 @@ class TestCompleteWorkflowExecution:
         )
 
         # Mock the runner
-        with patch("jentic.agent_runtime.tool_execution.OAKRunner") as mock_runner_class:
+        with patch("jentic.agent_runtime.tool_execution.ArazzoRunner") as mock_runner_class:
             mock_runner = MagicMock()  
             # Update return value structure
             mock_runner.execute_workflow.return_value = OakWorkflowExecutionResult(
@@ -362,7 +362,7 @@ class TestCompleteWorkflowExecution:
         )
 
         # Mock the runner to return an empty dictionary for outputs
-        with patch("jentic.agent_runtime.tool_execution.OAKRunner") as mock_runner_class:
+        with patch("jentic.agent_runtime.tool_execution.ArazzoRunner") as mock_runner_class:
             mock_runner = MagicMock()  
             # Update return value structure
             mock_runner.execute_workflow.return_value = OakWorkflowExecutionResult(
@@ -411,7 +411,7 @@ class TestEdgeCases:
         )
 
         # Mock the runner
-        with patch("jentic.agent_runtime.tool_execution.OAKRunner") as mock_runner_class:
+        with patch("jentic.agent_runtime.tool_execution.ArazzoRunner") as mock_runner_class:
             mock_runner = MagicMock()  
             # Update return value structure
             mock_runner.execute_workflow.return_value = OakWorkflowExecutionResult(
@@ -455,7 +455,7 @@ class TestEdgeCases:
         )
 
         # Create mock runner
-        with patch("jentic.agent_runtime.tool_execution.OAKRunner") as mock_runner_class:
+        with patch("jentic.agent_runtime.tool_execution.ArazzoRunner") as mock_runner_class:
             mock_runner = MagicMock()  
             # Runner returns final result directly
             # Update return value structure
@@ -508,7 +508,7 @@ class TestOperationExecution:
         oak_response_body = {"data": "success_data"}
         oak_full_response = {"status_code": 200, "body": oak_response_body, "headers": {}}
 
-        with patch("jentic.agent_runtime.tool_execution.OAKRunner") as mock_runner_class:
+        with patch("jentic.agent_runtime.tool_execution.ArazzoRunner") as mock_runner_class:
             mock_runner = MagicMock()
             mock_runner.execute_operation.return_value = oak_full_response
             mock_runner_class.return_value = mock_runner
@@ -543,7 +543,7 @@ class TestOperationExecution:
 
         oak_full_response = {"status_code": 204, "headers": {"X-Custom": "value"}} # No body for 204
 
-        with patch("jentic.agent_runtime.tool_execution.OAKRunner") as mock_runner_class:
+        with patch("jentic.agent_runtime.tool_execution.ArazzoRunner") as mock_runner_class:
             mock_runner = MagicMock()
             mock_runner.execute_operation.return_value = oak_full_response
             mock_runner_class.return_value = mock_runner
@@ -573,7 +573,7 @@ class TestOperationExecution:
         error_detail = {"error": "Bad Request", "message": "Invalid parameter provided"}
         oak_full_response = {"status_code": 400, "body": error_detail, "headers": {}}
 
-        with patch("jentic.agent_runtime.tool_execution.OAKRunner") as mock_runner_class:
+        with patch("jentic.agent_runtime.tool_execution.ArazzoRunner") as mock_runner_class:
             mock_runner = MagicMock()
             mock_runner.execute_operation.return_value = oak_full_response
             mock_runner_class.return_value = mock_runner
@@ -603,7 +603,7 @@ class TestOperationExecution:
 
         oak_full_response = {"status_code": 503, "body": "Service Unavailable", "headers": {}}
 
-        with patch("jentic.agent_runtime.tool_execution.OAKRunner") as mock_runner_class:
+        with patch("jentic.agent_runtime.tool_execution.ArazzoRunner") as mock_runner_class:
             mock_runner = MagicMock()
             mock_runner.execute_operation.return_value = oak_full_response
             mock_runner_class.return_value = mock_runner
@@ -633,7 +633,7 @@ class TestOperationExecution:
         oak_response_body = {"message": "OK"}
         oak_full_response = {"status_code": "201", "body": oak_response_body, "headers": {}}
 
-        with patch("jentic.agent_runtime.tool_execution.OAKRunner") as mock_runner_class:
+        with patch("jentic.agent_runtime.tool_execution.ArazzoRunner") as mock_runner_class:
             mock_runner = MagicMock()
             mock_runner.execute_operation.return_value = oak_full_response
             mock_runner_class.return_value = mock_runner
@@ -662,7 +662,7 @@ class TestOperationExecution:
 
         oak_full_response = {"status_code": "OK_NOT_A_NUMBER", "body": "Error", "headers": {}}
 
-        with patch("jentic.agent_runtime.tool_execution.OAKRunner") as mock_runner_class:
+        with patch("jentic.agent_runtime.tool_execution.ArazzoRunner") as mock_runner_class:
             mock_runner = MagicMock()
             mock_runner.execute_operation.return_value = oak_full_response
             mock_runner_class.return_value = mock_runner
@@ -678,7 +678,7 @@ class TestOperationExecution:
 
     @pytest.mark.asyncio
     async def test_execute_operation_missing_status_code(self, mock_api_hub_client):
-        """Test behavior when OAKRunner result is missing 'status_code'."""
+        """Test behavior when ArazzoRunner result is missing 'status_code'."""
         operation_uuid = "op_missing_status_uuid"
         inputs = {}
         mock_openapi_content = {"openapi": "3.0.0"}
@@ -693,7 +693,7 @@ class TestOperationExecution:
         # OAK result missing status_code
         oak_full_response = {"body": oak_response_body, "headers": {}}
 
-        with patch("jentic.agent_runtime.tool_execution.OAKRunner") as mock_runner_class:
+        with patch("jentic.agent_runtime.tool_execution.ArazzoRunner") as mock_runner_class:
             mock_runner = MagicMock()
             mock_runner.execute_operation.return_value = oak_full_response
             mock_runner_class.return_value = mock_runner
@@ -710,7 +710,7 @@ class TestOperationExecution:
 
     @pytest.mark.asyncio
     async def test_execute_operation_runner_returns_not_dict(self, mock_api_hub_client):
-        """Test behavior when OAKRunner returns a non-dictionary result."""
+        """Test behavior when ArazzoRunner returns a non-dictionary result."""
         operation_uuid = "op_runner_not_dict_uuid"
         inputs = {}
         mock_openapi_content = {"openapi": "3.0.0"}
@@ -721,10 +721,10 @@ class TestOperationExecution:
         )
         mock_api_hub_client.get_execution_files.return_value = mock_exec_files_response
 
-        # OAKRunner returns a string instead of a dict
+        # ArazzoRunner returns a string instead of a dict
         oak_non_dict_response = "This is not a dictionary"
 
-        with patch("jentic.agent_runtime.tool_execution.OAKRunner") as mock_runner_class:
+        with patch("jentic.agent_runtime.tool_execution.ArazzoRunner") as mock_runner_class:
             mock_runner = MagicMock()
             mock_runner.execute_operation.return_value = oak_non_dict_response
             mock_runner_class.return_value = mock_runner
@@ -748,11 +748,11 @@ class TestOperationExecution:
         mock_exec_files_response = GetFilesResponse(workflows={}, operations={}, files={})
         mock_api_hub_client.get_execution_files.return_value = mock_exec_files_response
 
-        with patch("jentic.agent_runtime.tool_execution.OAKRunner") as mock_runner_class:
+        with patch("jentic.agent_runtime.tool_execution.ArazzoRunner") as mock_runner_class:
             executor = TaskExecutor(api_hub_client=mock_api_hub_client)
             result = await executor.execute_operation(operation_uuid, inputs)
 
-            mock_runner_class.assert_not_called() # OAKRunner should not be initialized or called
+            mock_runner_class.assert_not_called() # ArazzoRunner should not be initialized or called
             assert result.success is False
             assert result.error == f"Operation ID {operation_uuid} not found in execution files response."
             assert result.status_code is None
@@ -778,7 +778,7 @@ class TestOperationExecution:
         )
         mock_api_hub_client.get_execution_files.return_value = mock_exec_files_response
 
-        with patch("jentic.agent_runtime.tool_execution.OAKRunner") as mock_runner_class:
+        with patch("jentic.agent_runtime.tool_execution.ArazzoRunner") as mock_runner_class:
             executor = TaskExecutor(api_hub_client=mock_api_hub_client)
             result = await executor.execute_operation(operation_uuid, inputs)
 
@@ -808,7 +808,7 @@ class TestOperationExecution:
         )
         mock_api_hub_client.get_execution_files.return_value = mock_exec_files_response
 
-        with patch("jentic.agent_runtime.tool_execution.OAKRunner") as mock_runner_class:
+        with patch("jentic.agent_runtime.tool_execution.ArazzoRunner") as mock_runner_class:
             executor = TaskExecutor(api_hub_client=mock_api_hub_client)
             result = await executor.execute_operation(operation_uuid, inputs)
 
@@ -828,7 +828,7 @@ class TestOperationExecution:
         expected_exception = RuntimeError("Network Error")
         mock_api_hub_client.get_execution_files.side_effect = expected_exception
 
-        with patch("jentic.agent_runtime.tool_execution.OAKRunner") as mock_runner_class:
+        with patch("jentic.agent_runtime.tool_execution.ArazzoRunner") as mock_runner_class:
             executor = TaskExecutor(api_hub_client=mock_api_hub_client)
             result = await executor.execute_operation(operation_uuid, inputs)
 

--- a/python/tests/api/test_api_hub.py
+++ b/python/tests/api/test_api_hub.py
@@ -51,10 +51,10 @@ def test_build_source_descriptions_happy_path(api_client):
     content2 = {"openapi": "3.0", "info": {"title": "API Two - Second File"}}
     all_openapi_files = {
         "file1_id": MockFileEntry(
-            id="file1_id", type="open_api", filename="api_one.json", content=content1, oak_path="./specs/api_one.json"
+            id="file1_id", type="open_api", filename="api_one.json", content=content1, source_path="./specs/api_one.json"
         ),
         "file2_id": MockFileEntry(
-            id="file2_id", type="open_api", filename="api_two.yaml", content=content2, oak_path="./specs/api_two.yaml"
+            id="file2_id", type="open_api", filename="api_two.yaml", content=content2, source_path="./specs/api_two.yaml"
         ),
     }
     # Sources with URLs that match the filenames
@@ -132,11 +132,11 @@ def test_build_source_descriptions_missing_file_in_response(api_client):
     content2 = {"info": "API Two - Content"}
     all_openapi_files = {
         "file2_id": MockFileEntry(
-            id="file2_id", type="open_api", filename="api_two.json", content=content2, oak_path="./actual_path/api_two.json"
+            id="file2_id", type="open_api", filename="api_two.json", content=content2, source_path="./actual_path/api_two.json"
         )
         # 'missing_id' is not present here, which is fine for this test's purpose.
     }
-    # Arazzo source with URL that doesn't match any oak_path
+    # Arazzo source with URL that doesn't match any source_path
     arazzo_source_name = "ApiSourceNoMatch"
     arazzo_doc = {
         "sourceDescriptions": [
@@ -150,7 +150,7 @@ def test_build_source_descriptions_missing_file_in_response(api_client):
         arazzo_doc=arazzo_doc,
     )
 
-    # With oak_path matching, if no exact match is found, the source is not included.
+    # With source_path matching, if no exact match is found, the source is not included.
     # The previous fallback logic is removed.
     assert len(result) == 0
     assert arazzo_source_name not in result


### PR DESCRIPTION
## Summary
- Replace OAKRunner with ArazzoRunner in all code and tests
- Update dependency from oak-runner to arazzo_runner>=0.8.14
- Update Python version requirement to >=3.11
- Update all imports and class references
- Update tool configurations for Python 3.11
- Bump SDK version to 0.8.2
- Migrate oak_path to source_path with full backward compatibility

## Changes
### ArazzoRunner Migration
- Updated all imports from `oak_runner` to `arazzo_runner`
- Changed class references from `OAKRunner` to `ArazzoRunner`
- Updated dependency to `arazzo_runner>=0.8.14`
- Updated Python version requirement to >=3.11
- Updated all test mocks and references

### oak_path to source_path Migration  
- Updated FileEntry model to use `source_path` as main field
- Added backward compatibility for `oak_path` field name
- Updated all code references to use `source_path`
- Maintained full backward compatibility - both field names work
- All tests pass with new field names