### PR TITLE
Update arazzo-runner to 0.8.20 and bump SDK to 0.9.3

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jentic"
-version = "0.9.2"
+version = "0.9.3"
 description = "Jentic SDK for the discovery and execution of APIs and workflows"
 requires-python = ">=3.11"
 readme = "README.md"
@@ -13,7 +13,7 @@ classifiers = [
     "Programming Language :: Python :: 3"
 ]
 dependencies = [
-    "arazzo-runner>=0.8.19",
+    "arazzo-runner>=0.8.20",
     "pydantic>=2.0.0",
     "httpx>=0.28.1",
     "tenacity>=9.1.2"


### PR DESCRIPTION
Updates arazzo-runner dependency to version 0.8.20 and increments the Python SDK version to 0.9.3.