### PR TITLE
Fix: Remove pushing sdk to PyPi-Test

### DIFF
--- a/.github/workflows/jentic-sdk-pypi.yaml
+++ b/.github/workflows/jentic-sdk-pypi.yaml
@@ -8,16 +8,6 @@ on:
       - main
     paths:
       - "python/**"
-  workflow_dispatch:
-    inputs:
-      publish_target:
-        description: "Where to publish"
-        required: true
-        default: "testpypi"
-        type: choice
-        options:
-          - testpypi
-          - pypi
 
 jobs:
   check-version:
@@ -80,9 +70,7 @@ jobs:
     needs:
     - build
     - check-version
-    if: |
-      needs.check-version.outputs.version_changed == 'true' ||
-      github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'pypi'
+    if: needs.check-version.outputs.version_changed == 'true'
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -98,31 +86,3 @@ jobs:
         path: dist/
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-
-  publish-to-testpypi:
-    name: Publish Python 🐍 distribution 📦 to TestPyPI
-    needs:
-    - build
-    - check-version
-    if: |
-      needs.check-version.outputs.version_changed == 'true' ||
-      github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'testpypi'
-    runs-on: ubuntu-latest
-
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/jentic
-
-    permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
-
-    steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-    - name: Publish distribution 📦 to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Remove pushing to test pypi, as well as the workflow-dispatch.  If we need to manually push to test server, we can add it back in, but i dont think we need it.