### PR TITLE
Add streamable HTTP transport mode for MCP

### DIFF
--- a/mcp/CLAUDE.md
+++ b/mcp/CLAUDE.md
@@ -12,8 +12,9 @@
 - Run specific test: `pdm run test tests/test_tools.py`
 - Run linters: `pdm run lint` (includes black, isort, ruff, mypy)
 - Run MCP HTTP server: `pdm run mcp-http`
+- Run MCP streamable HTTP server: `pdm run mcp-streamable-http`
 - Run MCP stdio mode: `pdm run mcp-stdio` (Note: Use only for ad hoc testing)
-- Run with mock data: `pdm run mcp-mock-http`, `pdm run mcp-mock-stdio`
+- Run with mock data: `pdm run mcp-mock-http`, `pdm run mcp-mock-streamable-http`, `pdm run mcp-mock-stdio`
 - Run with debug stdio: `pdm run mcp-debug-stdio`
 - Run with debug logging: `pdm run mcp serve --transport http --log-level DEBUG`
 - Log to file: `pdm run mcp serve --transport http --log-file jentic_mcp.log`

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -191,9 +191,16 @@ uvx --from \
 
 This automatically uses the default `serve --transport stdio` command defined in the `mcp` script's callback.
 
-### HTTP Mode
+### HTTP Modes
 
-To run the server in HTTP mode (e.g., for testing with `claude-cli`):
+The MCP server supports two HTTP transport modes:
+
+- **Standard HTTP**: Traditional request-response HTTP mode
+- **Streamable HTTP**: HTTP mode with streaming support, compatible with MCP Inspector
+
+#### Standard HTTP Mode
+
+To run the server in standard HTTP mode (e.g., for testing with `claude-cli`):
 
 **From Local Path (Development):**
 
@@ -214,6 +221,31 @@ uvx --from /path/to/your/project/mcp mcp serve --transport http --host 0.0.0.0 -
 uvx --from \
   git+https://github.com/jentic/jentic-sdks.git@main#subdirectory=mcp \
   mcp serve --transport http --port 8080
+```
+
+#### Streamable HTTP Mode
+
+To run the server in streamable HTTP mode (compatible with MCP Inspector):
+
+**From Local Path (Development):**
+
+```bash
+# Default streamable HTTP (port 8010)
+uvx --from /path/to/your/project/mcp mcp serve --transport streamable-http
+
+# With custom port
+uvx --from /path/to/your/project/mcp mcp serve --transport streamable-http --port 8080
+
+# With custom host
+uvx --from /path/to/your/project/mcp mcp serve --transport streamable-http --host 0.0.0.0 --port 8080
+```
+
+**From Remote Repository (Recommended):**
+
+```bash
+uvx --from \
+  git+https://github.com/jentic/jentic-sdks.git@main#subdirectory=mcp \
+  mcp serve --transport streamable-http --port 8080
 ```
 
 ### Running from a Remote Git Repository
@@ -249,6 +281,14 @@ uvx --from \
   serve --transport http --port 8080
 ```
 
+To run in streamable HTTP mode from a remote source:
+
+```bash
+uvx --from \
+  git+https://github.com/jentic/jentic-sdks.git@main#subdirectory=mcp \
+  serve --transport streamable-http --port 8080
+```
+
 ### Other Options
 
 #### Logging
@@ -257,10 +297,12 @@ uvx --from \
 # Set logging level (applies to default stdio or explicit serve)
 uvx --from /path/to/your/project/mcp mcp --log-level DEBUG
 uvx --from /path/to/your/project/mcp mcp serve --transport http --log-level DEBUG
+uvx --from /path/to/your/project/mcp mcp serve --transport streamable-http --log-level DEBUG
 
 # Log to file (applies to default stdio or explicit serve)
 uvx --from /path/to/your/project/mcp mcp --log-file jentic_mcp.log
 uvx --from /path/to/your/project/mcp mcp serve --transport http --log-file jentic_mcp.log
+uvx --from /path/to/your/project/mcp mcp serve --transport streamable-http --log-file jentic_mcp.log
 ```
 
 #### Mock Mode
@@ -273,6 +315,9 @@ uvx --from /path/to/your/project/mcp mcp --mock
 
 # Mock mode with explicit HTTP
 uvx --from /path/to/your/project/mcp mcp serve --transport http --mock
+
+# Mock mode with streamable HTTP
+uvx --from /path/to/your/project/mcp mcp serve --transport streamable-http --mock
 ```
 
 #### Environment Variables
@@ -285,6 +330,9 @@ uvx --from /path/to/your/project/mcp mcp --env-file .env
 
 # Env file with explicit HTTP
 uvx --from /path/to/your/project/mcp mcp serve --transport http --env-file .env
+
+# Env file with streamable HTTP
+uvx --from /path/to/your/project/mcp mcp serve --transport streamable-http --env-file .env
 ```
 
 ### Using with Claude
@@ -320,7 +368,6 @@ See [CLAUDE.md](CLAUDE.md) for detailed development instructions.
 ### Package Structure
 
 - `src/mcp/`: Main MCP package
-  - `transport/`: Transport implementations (HTTP, stdio)
   - `mock/`: Mock data providers for development
   - `tools.py`: Tool definitions
   - `handlers.py`: Request handlers

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -49,8 +49,10 @@ test = "pytest"
 test-real-integration = "python scripts/run_real_integration_test.py"
 # Keep mcp run commands for local pdm testing if desired
 mcp-http = "python -m mcp.main serve --transport http"
+mcp-streamable-http = "python -m mcp.main serve --transport streamable-http"
 mcp-stdio = "python -m mcp.main serve --transport stdio"
 mcp-mock-http = "python -m mcp.main serve --transport http --mock"
+mcp-mock-streamable-http = "python -m mcp.main serve --transport streamable-http --mock"
 mcp-mock-stdio = "python -m mcp.main serve --transport stdio --mock"
 mcp-debug-stdio = "python -m mcp.main serve --transport stdio --mock --debug-stdio --log-level DEBUG"
 

--- a/mcp/src/mcp/main.py
+++ b/mcp/src/mcp/main.py
@@ -92,6 +92,7 @@ class TransportMode(str, Enum):
     """Transport mode options."""
 
     HTTP = "http"
+    STREAMABLE_HTTP = "streamable-http"
     STDIO = "stdio"
 
 
@@ -116,7 +117,7 @@ def main(ctx: typer.Context):
 @app.command()
 def serve(
     transport: TransportMode = typer.Option(
-        TransportMode.HTTP, "--transport", "-t", help="Transport mode (http or stdio)"
+        TransportMode.HTTP, "--transport", "-t", help="Transport mode (http, streamable-http or stdio)"
     ),
     port: int = typer.Option(
         8010, "--port", "-p", help="Port to serve the MCP plugin on (HTTP mode only)"
@@ -175,6 +176,13 @@ def serve(
     # Initialize the appropriate transport
     if transport == TransportMode.HTTP:
         transport_instance = HTTPTransport(adapter, host=host, port=port)
+    elif transport == TransportMode.STREAMABLE_HTTP:
+        from mcp.transport.streamable_http import StreamableHTTPTransport
+        transport_instance = StreamableHTTPTransport(adapter, host=host, port=port)
+        logger.info(f"Starting Streamable HTTP server on {host}:{port}")
+        logger.info(f"GET/POST: http://{host}:{port}/")
+        logger.info(f"Health: http://{host}:{port}/health")
+        logger.info("Compatible with MCP Inspector!")
     else:  # stdio mode
         logger.info("ARK² MCP Plugin initializing in stdio mode")
         logger.info(f"Log file: {log_file or os.path.join(os.getcwd(), 'jentic_ark2_mcp.log')}")

--- a/mcp/src/mcp/transport/http_base.py
+++ b/mcp/src/mcp/transport/http_base.py
@@ -1,0 +1,137 @@
+"""Base HTTP transport with common functionality."""
+
+import asyncio
+import logging
+import signal
+import uuid
+from typing import Any, Dict
+
+import uvicorn
+from fastapi import FastAPI, Request, HTTPException
+from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.middleware.cors import CORSMiddleware
+
+from mcp.adapters.mcp import MCPAdapter
+from mcp.config import load_config
+from mcp.transport.base import BaseTransport
+from mcp.transport.jsonrpc_handler import JSONRPCHandler
+
+logger = logging.getLogger(__name__)
+
+
+class HTTPBaseTransport(BaseTransport):
+    """Base class for HTTP-based transports."""
+
+    def __init__(
+        self,
+        adapter: MCPAdapter,
+        host: str = "127.0.0.1",
+        port: int = 8010,
+        title: str = "Jentic MCP Server",
+    ):
+        """Initialize the HTTP base transport."""
+        self.adapter = adapter
+        self.host = host
+        self.port = port
+        self.config = load_config()
+        self._app = FastAPI(title=title)
+        self._server = None
+        self._running = False
+        self._active_connections: Dict[str, Dict[str, Any]] = {}
+        
+        # Common JSON-RPC handler
+        self.jsonrpc_handler = JSONRPCHandler(adapter)
+        
+        # Set up common middleware and routes
+        self._setup_common_middleware()
+        self._setup_common_routes()
+        self._setup_custom_routes()
+
+    def _setup_common_middleware(self) -> None:
+        """Set up common middleware (CORS, etc.)."""
+        self._app.add_middleware(
+            CORSMiddleware,
+            allow_origins=["*"],
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+
+    def _setup_common_routes(self) -> None:
+        """Set up common routes that all HTTP transports need."""
+        
+        @self._app.get("/health")
+        async def health_check():
+            """Health check endpoint."""
+            return JSONResponse({
+                "status": "ok", 
+                "transport": self.get_transport_name()
+            })
+
+    def _setup_custom_routes(self) -> None:
+        """Set up transport-specific routes. Override in subclasses."""
+        pass
+
+    def get_transport_name(self) -> str:
+        """Get the transport name. Override in subclasses."""
+        return "http-base"
+
+    async def handle_jsonrpc_request(self, data: dict) -> dict:
+        """Handle JSON-RPC request using the common handler."""
+        # Validate JSON-RPC format
+        if not isinstance(data, dict) or "jsonrpc" not in data or data["jsonrpc"] != "2.0":
+            raise HTTPException(status_code=400, detail="Invalid JSON-RPC request")
+        
+        method = data.get("method")
+        if not method:
+            raise HTTPException(status_code=400, detail="Missing method in JSON-RPC request")
+        
+        return await self.jsonrpc_handler.handle_request(data)
+
+    def create_error_response(self, data: dict, error_message: str, error_code: int = -32603) -> dict:
+        """Create a JSON-RPC error response."""
+        return {
+            "jsonrpc": "2.0",
+            "id": data.get("id") if isinstance(data, dict) else None,
+            "error": {
+                "code": error_code,
+                "message": error_message
+            }
+        }
+
+    async def start(self) -> None:
+        """Start the HTTP server."""
+        config = uvicorn.Config(
+            app=self._app, 
+            host=self.host, 
+            port=self.port, 
+            log_level="info"
+        )
+        self._server = uvicorn.Server(config)
+        self._running = True
+
+        # Handle termination gracefully
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            signal.signal(sig, self._handle_exit)
+
+        logger.info(f"Starting {self.get_transport_name()} server on {self.host}:{self.port}")
+        await self._server.serve()
+
+    async def stop(self) -> None:
+        """Stop the HTTP server."""
+        if self._server and self._running:
+            self._running = False
+            if hasattr(self._server, "should_exit"):
+                self._server.should_exit = True
+            logger.info(f"{self.get_transport_name()} server stopped")
+
+    @property
+    def is_running(self) -> bool:
+        """Check if the HTTP server is running."""
+        return self._running
+
+    def _handle_exit(self, signum, frame):
+        """Handle exit signals."""
+        logger.info(f"Received signal {signum}, shutting down {self.get_transport_name()} server...")
+        if self._server:
+            self._server.should_exit = True

--- a/mcp/src/mcp/transport/jsonrpc_handler.py
+++ b/mcp/src/mcp/transport/jsonrpc_handler.py
@@ -1,0 +1,175 @@
+"""Common JSON-RPC handler for MCP protocol."""
+
+import json
+import logging
+from typing import Any, Dict
+
+from mcp.adapters.mcp import MCPAdapter
+from mcp import version
+
+logger = logging.getLogger(__name__)
+
+
+class JSONRPCHandler:
+    """Common JSON-RPC handler for MCP protocol."""
+
+    def __init__(self, adapter: MCPAdapter):
+        """Initialize the JSON-RPC handler."""
+        self.adapter = adapter
+
+    async def handle_request(self, data: dict) -> dict:
+        """Handle a JSON-RPC request and return the response."""
+        method = data.get("method")
+        params = data.get("params", {})
+        request_id = data.get("id")
+
+        logger.info(f"Handling JSON-RPC method: {method} (id: {request_id})")
+
+        try:
+            if method == "initialize":
+                return await self._handle_initialize(params, request_id)
+            elif method == "notifications/initialized":
+                # Handle initialized notification (no response needed)
+                logger.info("Client initialization complete")
+                return None
+            elif method == "tools/list":
+                return await self._handle_tools_list(params, request_id)
+            elif method == "tools/call":
+                return await self._handle_tools_call(params, request_id)
+            elif method == "ping":
+                return {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "result": {"pong": True}
+                }
+            else:
+                return {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "error": {
+                        "code": -32601,
+                        "message": f"Method not found: {method}",
+                    },
+                }
+        except Exception as e:
+            logger.error(f"Error handling JSON-RPC method {method}: {e}")
+            return {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {
+                    "code": -32603,
+                    "message": f"Internal error: {str(e)}",
+                },
+            }
+
+    async def _handle_initialize(self, params: dict, request_id: Any) -> dict:
+        """Handle initialize request."""
+        logger.info(f"Handling initialize request (id: {request_id})")
+        
+        # Extract client info
+        client_info = params.get("clientInfo", {})
+        protocol_version = params.get("protocolVersion", "2024-11-05")
+        
+        logger.info(f"Client: {client_info.get('name', 'unknown')} v{client_info.get('version', 'unknown')}")
+        
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "protocolVersion": protocol_version,
+                "capabilities": {
+                    "tools": {},
+                },
+                "serverInfo": {
+                    "name": "jentic",
+                    "version": version.__version__
+                },
+            },
+        }
+
+    async def _handle_tools_list(self, params: dict, request_id: Any) -> dict:
+        """Handle tools/list request."""
+        logger.info(f"Handling tools/list request (id: {request_id})")
+        
+        from mcp.tools import get_all_tool_definitions
+        tool_definitions = get_all_tool_definitions()
+        
+        tools = []
+        for tool in tool_definitions:
+            tools.append({
+                "name": tool["name"],
+                "description": tool["description"],
+                "inputSchema": {
+                    "type": "object",
+                    "properties": tool["parameters"]["properties"],
+                    "required": tool["parameters"].get("required", []),
+                },
+            })
+        
+        logger.info(f"Returning {len(tools)} tools")
+        
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "tools": tools
+            },
+        }
+
+    async def _handle_tools_call(self, params: dict, request_id: Any) -> dict:
+        """Handle tools/call request."""
+        tool_name = params.get("name")
+        arguments = params.get("arguments", {})
+        
+        logger.info(f"Handling tools/call for {tool_name} (id: {request_id})")
+        
+        # Map tool names to adapter methods
+        tool_handlers = {
+            "search_apis": self.adapter.search_api_capabilities,
+            "load_execution_info": self.adapter.generate_runtime_config,
+            "execute": self.adapter.execute,
+            "submit_feedback": self.adapter.submit_feedback,
+        }
+        
+        if tool_name not in tool_handlers:
+            return {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {
+                    "code": -32601,
+                    "message": f"Tool not found: {tool_name}",
+                },
+            }
+        
+        try:
+            result = await tool_handlers[tool_name](arguments)
+            logger.info(f"Tool {tool_name} executed successfully")
+            
+            # Format result - extract actual result if wrapped
+            if isinstance(result, dict) and "result" in result:
+                actual_result = result["result"]
+            else:
+                actual_result = result
+            
+            return {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": json.dumps(actual_result, indent=2)
+                        }
+                    ]
+                },
+            }
+        except Exception as e:
+            logger.error(f"Error executing tool {tool_name}: {e}")
+            return {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {
+                    "code": -32603,
+                    "message": f"Tool execution error: {str(e)}",
+                },
+            }

--- a/mcp/src/mcp/transport/streamable_http.py
+++ b/mcp/src/mcp/transport/streamable_http.py
@@ -1,0 +1,126 @@
+"""Streamable HTTP transport for MCP Inspector compatibility."""
+
+import asyncio
+import json
+import logging
+import uuid
+
+from fastapi import Request, HTTPException
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from mcp.adapters.mcp import MCPAdapter
+from mcp.transport.http_base import HTTPBaseTransport
+
+logger = logging.getLogger(__name__)
+
+
+class StreamableHTTPTransport(HTTPBaseTransport):
+    """Streamable HTTP transport for MCP Inspector."""
+
+    def __init__(
+        self,
+        adapter: MCPAdapter,
+        host: str = "127.0.0.1",
+        port: int = 8010,
+    ):
+        """Initialize the Streamable HTTP transport."""
+        super().__init__(
+            adapter=adapter,
+            host=host,
+            port=port,
+            title="Jentic MCP Server (Streamable HTTP)"
+        )
+
+    def get_transport_name(self) -> str:
+        """Get the transport name."""
+        return "streamable-http"
+
+    def _setup_custom_routes(self) -> None:
+        """Set up Streamable HTTP specific routes."""
+        
+        @self._app.get("/")
+        async def streamable_http_sse(request: Request):
+            """GET / - Streamable HTTP SSE endpoint."""
+            logger.info("Streamable HTTP SSE connection established")
+            
+            async def event_stream():
+                connection_id = str(uuid.uuid4())
+                
+                try:
+                    # Store connection
+                    self._active_connections[connection_id] = {
+                        "request": request,
+                        "message_queue": asyncio.Queue()
+                    }
+                    
+                    # Send initial notification
+                    initial_message = {
+                        "jsonrpc": "2.0",
+                        "method": "notifications/initialized",
+                        "params": {}
+                    }
+                    
+                    yield f"data: {json.dumps(initial_message)}\n\n"
+                    
+                    # Process message queue
+                    while True:
+                        try:
+                            if await request.is_disconnected():
+                                break
+                            
+                            try:
+                                message = await asyncio.wait_for(
+                                    self._active_connections[connection_id]["message_queue"].get(),
+                                    timeout=1.0
+                                )
+                                yield f"data: {json.dumps(message)}\n\n"
+                            except asyncio.TimeoutError:
+                                # Send keep-alive
+                                yield f": keep-alive\n\n"
+                                
+                        except asyncio.CancelledError:
+                            break
+                        
+                except Exception as e:
+                    logger.error(f"SSE connection error: {e}")
+                finally:
+                    # Clean up connection
+                    if connection_id in self._active_connections:
+                        del self._active_connections[connection_id]
+            
+            return StreamingResponse(
+                event_stream(),
+                media_type="text/event-stream",
+                headers={
+                    "Cache-Control": "no-cache",
+                    "Connection": "keep-alive",
+                    "Access-Control-Allow-Origin": "*",
+                }
+            )
+
+        @self._app.post("/")
+        async def streamable_http_post(request: Request):
+            """POST / - Handle JSON-RPC messages."""
+            try:
+                data = await request.json()
+                
+                # Use the common JSON-RPC handler
+                response = await self.handle_jsonrpc_request(data)
+                
+                # Send response to all active connections via SSE
+                for connection_info in self._active_connections.values():
+                    if "message_queue" in connection_info:
+                        await connection_info["message_queue"].put(response)
+                
+                return JSONResponse(response)
+                
+            except HTTPException:
+                # Re-raise HTTP exceptions
+                raise
+            except Exception as e:
+                logger.error(f"Error processing message: {e}")
+                error_response = self.create_error_response(
+                    data if 'data' in locals() else {}, 
+                    f"Internal error: {str(e)}"
+                )
+                return JSONResponse(error_response, status_code=500)


### PR DESCRIPTION
This PR introduces a new 'streamable-http' transport for the MCP server so tools can stream results over HTTP. It makes local testing and inspection straightforward with MCP Inspector while keeping existing transports unchanged. Docs and helper commands are updated accordingly.

## Why

* Enable streaming over HTTP for a smoother developer workflow.
* Allow quick end-to-end testing with MCP Inspector, without special client setup.
* Preserve existing behaviour - default transport remains 'http' and 'stdio' still supported.

## What changed

* `mcp/src/mcp/main.py`: added `TransportMode.STREAMABLE_HTTP` and server wiring.
* `mcp/src/mcp/transport/streamable_http.py`: new transport implementation.
* `mcp/src/mcp/transport/http_base.py` and `jsonrpc_handler.py`: shared HTTP helpers for clean separation.
* `mcp/pyproject.toml`: new run targets `mcp-streamable-http` and `mcp-mock-streamable-http`.
* `mcp/README.md` and `mcp/CLAUDE.md`: documented 'streamable-http' mode.

## How to test with MCP Inspector

> Demo video attached in the PR.

1. **Run the MCP server in streamable HTTP mode**
   From the repo root or the `mcp` subfolder:

   ```bash
   uvx --from ./mcp mcp serve -t streamable-http -p 8080
   ```

   * Default port is 8010 if you omit `-p`.
   * You can pass `--mock` and `--log-level DEBUG` if useful.

2. **Start MCP Inspector**
   Using Bun:

   ```bash
   bunx @modelcontextprotocol/inspector
   ```

   or using Node and NPM:

   ```bash
   npx @modelcontextprotocol/inspector
   ```

3. **Connect from Inspector**

   * Open the Inspector URL that appears in your terminal.
   * Transport Type: 'Streamable HTTP'
   * URL: `http://127.0.0.1:8080`
   * Click 'Connect'.
   * Go to 'Tools' → 'List tools' to see the server’s tools, then try any tool as usual.

### Alternative: run directly from Git without cloning

```bash
uvx --from \
  git+https://github.com/jentic/jentic-sdks.git@main#subdirectory=mcp \
  mcp serve --transport streamable-http --port 8080
```

This uses the published repo to launch the same server and is also compatible with MCP Inspector.

## Backwards compatibility

* No breaking changes.

## Notes

* Health and base endpoints are logged on start to aid discovery.
* Streamable mode is explicitly marked as compatible with MCP Inspector.

## Demo video

https://github.com/user-attachments/assets/bb41da83-26f0-4dd5-9efc-ccaa673c4de9